### PR TITLE
Improve C# messages

### DIFF
--- a/IDRSolutions/IDRCloudClient.cs
+++ b/IDRSolutions/IDRCloudClient.cs
@@ -195,16 +195,16 @@ namespace idrsolutions_csharp_client
             }
 
             var response = _restClient.Execute(request);
-            if (response.ErrorException != null)
-            {
-                throw new Exception("Error uploading file:\n" + response.ErrorException.GetType() + "\n"
-                                    + response.ErrorMessage);
-            }
-
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 throw new Exception("Error uploading file:\nServer returned response\n" + response.StatusCode + ":\n"
                                     + response.Content);
+            }
+
+            if (response.ErrorException != null)
+            {
+                throw new Exception("Error uploading file:\n" + response.ErrorException.GetType() + "\n"
+                                    + response.ErrorException.Message);
             }
 
             var content = response.Content;
@@ -229,16 +229,16 @@ namespace idrsolutions_csharp_client
 
             var response = _restClient.Execute(request);
 
-            if (response.ErrorException != null)
-            {
-                throw new Exception("Error checking conversion status:\n" + response.ErrorException.GetType() + "\n"
-                                    + response.ErrorMessage);
-            }
-
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 throw new Exception("Error checking conversion status:\n Server returned response\n"
-                                    + response.StatusCode + " - " + response.StatusDescription);
+                                    + response.StatusCode + " - " + response.Content);
+            }
+
+            if (response.ErrorException != null)
+            {
+                throw new Exception("Error checking conversion status:\n" + response.ErrorException.GetType() + "\n"
+                                    + response.ErrorException.Message);
             }
 
             return response;


### PR DESCRIPTION
The C# client does not return useful error messages as it grabs the incorrect values from the exception.

Update now grabs the correct values and check the status code before the exception. Reason being status codes can also return an exception. Now we handle all status code the same way and only handle the exception is an exception prevents the request returning a status code.